### PR TITLE
Handle missing refresh token cookie

### DIFF
--- a/Presentation.Tests/CookieServiceTests.cs
+++ b/Presentation.Tests/CookieServiceTests.cs
@@ -1,0 +1,30 @@
+using Infrastructure.Services;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Presentation.Tests
+{
+    public class CookieServiceTests
+    {
+        private readonly CookieService _cookieService = new();
+
+        [Fact]
+        public void GetRefreshTokenFromRequest_ReturnsNull_WhenCookieMissing()
+        {
+            var context = new DefaultHttpContext();
+            var token = _cookieService.GetRefreshTokenFromRequest(context.Request);
+            Assert.Null(token);
+        }
+
+        [Fact]
+        public void GetRefreshTokenFromRequest_ReturnsToken_WhenCookieExists()
+        {
+            var context = new DefaultHttpContext();
+            context.Request.Headers["Cookie"] = "refresh-token=test-token";
+
+            var token = _cookieService.GetRefreshTokenFromRequest(context.Request);
+
+            Assert.Equal("test-token", token);
+        }
+    }
+}

--- a/src/Infrastructure/Services/CookieService.cs
+++ b/src/Infrastructure/Services/CookieService.cs
@@ -20,9 +20,11 @@ namespace Infrastructure.Services
             response.Cookies.Append(RefreshTokenKey, refreshToken, cookieOptions);
         }
 
-        public string GetRefreshTokenFromRequest(HttpRequest request)
+        public string? GetRefreshTokenFromRequest(HttpRequest request)
         {
-            return request.Cookies[RefreshTokenKey];
+            return request.Cookies.TryGetValue(RefreshTokenKey, out var token)
+                ? token
+                : null;
         }
 
         public void RemoveRefreshTokenCookie(HttpResponse response)

--- a/src/Infrastructure/Services/ICookieService.cs
+++ b/src/Infrastructure/Services/ICookieService.cs
@@ -5,7 +5,7 @@ namespace Infrastructure.Services
     public interface ICookieService
     {
         void SetRefreshTokenCookie(HttpResponse response, string refreshToken, int expirationDays);
-        string GetRefreshTokenFromRequest(HttpRequest request);
+        string? GetRefreshTokenFromRequest(HttpRequest request);
         void RemoveRefreshTokenCookie(HttpResponse response);
     }
 }


### PR DESCRIPTION
## Summary
- Return nullable refresh token and guard missing cookies
- Add cookie service tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6898028f167c8329826e4e53d95a2303